### PR TITLE
カレンダーのデバッグ

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -2,6 +2,6 @@ class CalendarsController < ApplicationController
   before_action :authenticate_user!, only: [:index]
 
   def index
-    @tasks = current_user.tasks
+    @tasks = current_user.tasks.where(archived: false)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
 
   resources :users, only: [:show, :edit, :update]
 
-  # 論理削除用のルーティング
   patch '/users/:id/withdrawal' => 'users#withdrawal', as: 'withdrawal'
 
   resources :tasks do


### PR DESCRIPTION
#what
カレンダーにはアーカイブされていないタスクの期限のみが表示されるようにコントローラーを編集。

#why
カレンダーにアーカイブされたタスクの期限が表示されるため、デバッグするため。