### PR TITLE
一覧でタスクが2個表示されるバグを解消

### DIFF
--- a/app/services/task_filter_service.rb
+++ b/app/services/task_filter_service.rb
@@ -30,6 +30,7 @@ class TaskFilterService
                                        .where(subtasks: { subtask_deadline: nil })
                                        .order(task_deadline: :asc)
 
-    urgent_important_tasks + urgent_tasks + important_tasks + important_tasks_without_subtasks + other_tasks + other_tasks_without_subtasks
+    (urgent_important_tasks + urgent_tasks + important_tasks + important_tasks_without_subtasks + other_tasks + other_tasks_without_subtasks).uniq { |task| task.id }
+
   end
 end


### PR DESCRIPTION
#what
一覧機能のサービスクラスのタスクのフィルタリングを修正
#why
一覧でサブタスクが3日以内のものと、そうでないものがあると2回表示されるバグを修正